### PR TITLE
Remove git submodules and let cargo mange that

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/ur-rs"]
-	path = libs/ur-rs
-	url = git@github.com:KeystoneHQ/ur-rs.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "checked_int_cast"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,15 +118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "qrcode"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
-dependencies = [
- "checked_int_cast",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,13 +188,13 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "ur"
 version = "0.2.0"
+source = "git+https://github.com/KeystoneHQ/ur-rs.git?rev=5f673a1#5f673a15d5f63e71b9707a0c46df60f158684b49"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
  "crc",
  "hex",
  "once_cell",
- "qrcode",
  "rand_xoshiro",
  "serde",
  "serde_cbor",

--- a/libs/ur-registry-ffi/Cargo.toml
+++ b/libs/ur-registry-ffi/Cargo.toml
@@ -8,8 +8,12 @@ edition = "2021"
 [dependencies]
 hex = "0.4.3"
 secp256k1 = "0.24.0"
-ur = { path = "../ur-rs" }
 ur-registry = { path = "../ur-registry" }
+
+[dependencies.ur]
+git = "https://github.com/KeystoneHQ/ur-rs.git"
+rev = "5f673a1"
+version = "0.2.0"
 
 [lib]
 name = "ur_registry_ffi"

--- a/libs/ur-registry/Cargo.toml
+++ b/libs/ur-registry/Cargo.toml
@@ -6,7 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ur = {path = "../ur-rs"}
 serde_cbor = "0.11.2"
 hex = "0.4.3"
-bs58 = {version = "0.4.0", features=['check']}
+bs58 = { version = "0.4.0", features=['check'] }
+
+[dependencies.ur]
+git = "https://github.com/KeystoneHQ/ur-rs.git"
+rev = "5f673a1"
+version = "0.2.0"


### PR DESCRIPTION
### Overview

Hello, I did notice that you are using git submodules with a `ssh+git`, which is not the best, instead we can let cargo itself manage these dependencies for us.

### Use cases

I'm building a simple CLI wallet, [shekozwallet](https://github.com/shekohex/wallet), and I noticed a few things while working on that wallet is the git submodules issues starts to rise when it comes to [CI](https://github.com/shekohex/wallet/actions/runs/3570252515/jobs/6001057069) or machines that does not have SSH agent configured.

With this change, there will be no need for SSH stuff, and it is even simpler to update the dependencies from inside the Cargo.toml itself.