### PR TITLE
Fix iOS SPM FFI symbol retention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,12 @@ generate_ios:
 	cargo build --release --target x86_64-apple-ios -p ur-registry-ffi
 	@echo "Creating simulator fat library"
 	mkdir -p target/sim
+	rm -f target/sim/libur_registry_ffi.a
 	lipo target/aarch64-apple-ios-sim/release/libur_registry_ffi.a \
 	     target/x86_64-apple-ios/release/libur_registry_ffi.a \
 	     -create -output target/sim/libur_registry_ffi.a
 	@echo "Creating XCFramework"
+	rm -rf target/URRegistryFFI.xcframework $(FLUTTER_PLUGIN)/ios/ur_registry_flutter/ur_registry_ffi.xcframework
 	xcodebuild -create-xcframework \
 	    -library target/aarch64-apple-ios/release/libur_registry_ffi.a -headers $(HEADERS) \
 	    -library target/sim/libur_registry_ffi.a -headers $(HEADERS) \
@@ -75,10 +77,12 @@ generate_ios_debug:
 	cargo build --target x86_64-apple-ios -p ur-registry-ffi
 	@echo "Creating simulator fat library"
 	mkdir -p target/sim
+	rm -f target/sim/libur_registry_ffi.a
 	lipo target/aarch64-apple-ios-sim/debug/libur_registry_ffi.a \
 	     target/x86_64-apple-ios/debug/libur_registry_ffi.a \
 	     -create -output target/sim/libur_registry_ffi.a
 	@echo "Creating XCFramework"
+	rm -rf target/URRegistryFFI.xcframework $(FLUTTER_PLUGIN)/ios/ur_registry_flutter/ur_registry_ffi.xcframework
 	xcodebuild -create-xcframework \
 	    -library target/aarch64-apple-ios/debug/libur_registry_ffi.a -headers $(HEADERS) \
 	    -library target/sim/libur_registry_ffi.a -headers $(HEADERS) \

--- a/include/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/include/URRegistryFFI/lib_ur_registry_ffi.h
@@ -102,6 +102,114 @@ PtrResponse eth_signature_get_signature(void *eth_signarure);
 
 PtrResponse eth_signature_get_request_id(void *eth_signature);
 
+PtrResponse cardano_sign_request_new(void);
+
+PtrResponse cardano_sign_request_construct(void *request_id,
+                                           void *sign_data,
+                                           void *utxos,
+                                           void *cert_keys,
+                                           void *origin);
+
+PtrResponse cardano_sign_request_get_ur_encoder(void *cardano_sign_request);
+
+PtrResponse cardano_sign_request_get_request_id(void *cardano_sign_request);
+
+PtrResponse cardano_signature_get_witness_set(void *cardano_signature);
+
+PtrResponse cardano_signature_get_request_id(void *cardano_signature);
+
+PtrResponse cardano_sign_data_request_new(void);
+
+PtrResponse cardano_sign_data_request_construct(void *request_id,
+                                                void *mfp,
+                                                void *sign_data,
+                                                void *derivation_path,
+                                                void *origin,
+                                                void *xpub);
+
+PtrResponse cardano_sign_data_request_get_ur_encoder(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_request_get_request_id(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_signature_new(void);
+
+PtrResponse cardano_sign_data_signature_construct(void *request_id,
+                                                  void *signature,
+                                                  void *public_key);
+
+PtrResponse cardano_sign_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_request_new(void);
+
+PtrResponse cardano_sign_cip8_data_request_construct(void *request_id,
+                                                     void *mfp,
+                                                     void *sign_data,
+                                                     void *derivation_path,
+                                                     void *xpub,
+                                                     void *origin,
+                                                     bool hash_payload,
+                                                     void *address_bench32,
+                                                     uint32_t address_type);
+
+PtrResponse cardano_sign_cip8_data_request_get_ur_encoder(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_request_get_request_id(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_signature_new(void);
+
+PtrResponse cardano_sign_cip8_data_signature_construct(void *request_id,
+                                                       void *signature,
+                                                       void *public_key,
+                                                       void *address_field);
+
+PtrResponse cardano_sign_cip8_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_address_field(void *signature);
+
+PtrResponse cardano_catalyst_voting_registration_new(void);
+
+PtrResponse cardano_catalyst_voting_registration_construct(void *request_id,
+                                                           void *mfp,
+                                                           void *delegations,
+                                                           void *stake_pub,
+                                                           void *payment_address,
+                                                           void *nonce,
+                                                           uint8_t voting_purpose,
+                                                           void *derivation_path,
+                                                           void *origin,
+                                                           uint8_t sign_type);
+
+PtrResponse cardano_catalyst_voting_registration_get_ur_encoder(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_voting_registration_get_request_id(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_signature_new(void);
+
+PtrResponse cardano_catalyst_signature_construct(void *request_id,
+                                                 void *signature);
+
+PtrResponse cardano_catalyst_signature_get_request_id(void *catalyst_signature);
+
+PtrResponse cardano_catalyst_signature_get_signature(void *catalyst_signature);
+
+PtrResponse cardano_sign_tx_hash_request_construct(void *request_id,
+                                                   void *tx_hash,
+                                                   void *paths,
+                                                   void *origin,
+                                                   void *address_list);
+
+PtrResponse cardano_sign_tx_hash_request_get_ur_encoder(void *cardano_sign_tx_hash_request);
+
+PtrResponse cardano_sign_tx_hash_request_get_request_id(void *cardano_sign_tx_hash_request);
+
 PtrResponse ur_decoder_new(void);
 
 PtrResponse ur_decoder_receive(void *decoder, void *ur);

--- a/include/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/include/URRegistryFFI/lib_ur_registry_ffi.h
@@ -40,6 +40,8 @@ PtrResponse crypto_hd_key_get_name(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_path(void *crypto_hdkey);
 
+PtrResponse crypto_hd_key_get_children_path(void *crypto_hdkey);
+
 PtrResponse crypto_hd_key_get_source_fingerprint(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
@@ -47,6 +49,8 @@ PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
 PtrResponse crypto_hd_key_get_depth(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_note(void *crypto_hdkey);
+
+PtrResponse crypto_hd_key_get_bip32_xpub(void *crypto_hdkey);
 
 PtrResponse crypto_account_get_accounts_len(void *crypto_account);
 

--- a/interfaces/ur_registry_flutter/CHANGELOG.md
+++ b/interfaces/ur_registry_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1
+- Fixed iOS Swift Package Manager builds to keep all Dart FFI lookup symbols available at runtime.
+- Added missing iOS header declarations for Cardano and HD key FFI functions.
+- Made iOS XCFramework generation idempotent.
+
 ## 0.5.0
 - Replaced iOS fat binary with XCFramework (fixes Xcode 26+ arm64 simulator support)
 - Added Swift Package Manager support for iOS

--- a/interfaces/ur_registry_flutter/include/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/interfaces/ur_registry_flutter/include/URRegistryFFI/lib_ur_registry_ffi.h
@@ -99,6 +99,114 @@ PtrResponse eth_signature_get_signature(void *eth_signarure);
 
 PtrResponse eth_signature_get_request_id(void *eth_signature);
 
+PtrResponse cardano_sign_request_new(void);
+
+PtrResponse cardano_sign_request_construct(void *request_id,
+                                           void *sign_data,
+                                           void *utxos,
+                                           void *cert_keys,
+                                           void *origin);
+
+PtrResponse cardano_sign_request_get_ur_encoder(void *cardano_sign_request);
+
+PtrResponse cardano_sign_request_get_request_id(void *cardano_sign_request);
+
+PtrResponse cardano_signature_get_witness_set(void *cardano_signature);
+
+PtrResponse cardano_signature_get_request_id(void *cardano_signature);
+
+PtrResponse cardano_sign_data_request_new(void);
+
+PtrResponse cardano_sign_data_request_construct(void *request_id,
+                                                void *mfp,
+                                                void *sign_data,
+                                                void *derivation_path,
+                                                void *origin,
+                                                void *xpub);
+
+PtrResponse cardano_sign_data_request_get_ur_encoder(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_request_get_request_id(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_signature_new(void);
+
+PtrResponse cardano_sign_data_signature_construct(void *request_id,
+                                                  void *signature,
+                                                  void *public_key);
+
+PtrResponse cardano_sign_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_request_new(void);
+
+PtrResponse cardano_sign_cip8_data_request_construct(void *request_id,
+                                                     void *mfp,
+                                                     void *sign_data,
+                                                     void *derivation_path,
+                                                     void *xpub,
+                                                     void *origin,
+                                                     bool hash_payload,
+                                                     void *address_bench32,
+                                                     uint32_t address_type);
+
+PtrResponse cardano_sign_cip8_data_request_get_ur_encoder(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_request_get_request_id(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_signature_new(void);
+
+PtrResponse cardano_sign_cip8_data_signature_construct(void *request_id,
+                                                       void *signature,
+                                                       void *public_key,
+                                                       void *address_field);
+
+PtrResponse cardano_sign_cip8_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_address_field(void *signature);
+
+PtrResponse cardano_catalyst_voting_registration_new(void);
+
+PtrResponse cardano_catalyst_voting_registration_construct(void *request_id,
+                                                           void *mfp,
+                                                           void *delegations,
+                                                           void *stake_pub,
+                                                           void *payment_address,
+                                                           void *nonce,
+                                                           uint8_t voting_purpose,
+                                                           void *derivation_path,
+                                                           void *origin,
+                                                           uint8_t sign_type);
+
+PtrResponse cardano_catalyst_voting_registration_get_ur_encoder(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_voting_registration_get_request_id(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_signature_new(void);
+
+PtrResponse cardano_catalyst_signature_construct(void *request_id,
+                                                 void *signature);
+
+PtrResponse cardano_catalyst_signature_get_request_id(void *catalyst_signature);
+
+PtrResponse cardano_catalyst_signature_get_signature(void *catalyst_signature);
+
+PtrResponse cardano_sign_tx_hash_request_construct(void *request_id,
+                                                   void *tx_hash,
+                                                   void *paths,
+                                                   void *origin,
+                                                   void *address_list);
+
+PtrResponse cardano_sign_tx_hash_request_get_ur_encoder(void *cardano_sign_tx_hash_request);
+
+PtrResponse cardano_sign_tx_hash_request_get_request_id(void *cardano_sign_tx_hash_request);
+
 PtrResponse extend_crypto_multi_accounts_get_master_fingerprint(void *crypto_multi_accounts);
 
 PtrResponse extend_crypto_multi_accounts_get_device(void *crypto_multi_accounts);

--- a/interfaces/ur_registry_flutter/include/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/interfaces/ur_registry_flutter/include/URRegistryFFI/lib_ur_registry_ffi.h
@@ -40,6 +40,8 @@ PtrResponse crypto_hd_key_get_name(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_path(void *crypto_hdkey);
 
+PtrResponse crypto_hd_key_get_children_path(void *crypto_hdkey);
+
 PtrResponse crypto_hd_key_get_source_fingerprint(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
@@ -47,6 +49,8 @@ PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
 PtrResponse crypto_hd_key_get_depth(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_note(void *crypto_hdkey);
+
+PtrResponse crypto_hd_key_get_bip32_xpub(void *crypto_hdkey);
 
 PtrResponse crypto_account_get_accounts_len(void *crypto_account);
 

--- a/interfaces/ur_registry_flutter/ios/ur_registry_flutter/Sources/ur_registry_flutter/SwiftUrRegistryFlutterPlugin.swift
+++ b/interfaces/ur_registry_flutter/ios/ur_registry_flutter/Sources/ur_registry_flutter/SwiftUrRegistryFlutterPlugin.swift
@@ -24,10 +24,12 @@ public class SwiftUrRegistryFlutterPlugin: NSObject, FlutterPlugin {
     crypto_hd_key_get_chain_code(anyPointer);
     crypto_hd_key_get_name(anyPointer);
     crypto_hd_key_get_path(anyPointer);
+    crypto_hd_key_get_children_path(anyPointer);
     crypto_hd_key_get_source_fingerprint(anyPointer);
     crypto_hd_key_get_account_index(anyPointer, 1);
     crypto_hd_key_get_depth(anyPointer);
     crypto_hd_key_get_note(anyPointer);
+    crypto_hd_key_get_bip32_xpub(anyPointer);
 
     crypto_account_get_accounts_len(anyPointer);
     crypto_account_get_account(anyPointer, 1);

--- a/interfaces/ur_registry_flutter/ios/ur_registry_flutter/Sources/ur_registry_flutter/SwiftUrRegistryFlutterPlugin.swift
+++ b/interfaces/ur_registry_flutter/ios/ur_registry_flutter/Sources/ur_registry_flutter/SwiftUrRegistryFlutterPlugin.swift
@@ -20,11 +20,14 @@ public class SwiftUrRegistryFlutterPlugin: NSObject, FlutterPlugin {
     let anyPointer = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 1);
 
     crypto_hd_key_get_key_data(anyPointer);
+    crypto_hd_key_get_uncompressed_key_data(anyPointer);
+    crypto_hd_key_get_chain_code(anyPointer);
     crypto_hd_key_get_name(anyPointer);
     crypto_hd_key_get_path(anyPointer);
     crypto_hd_key_get_source_fingerprint(anyPointer);
     crypto_hd_key_get_account_index(anyPointer, 1);
     crypto_hd_key_get_depth(anyPointer);
+    crypto_hd_key_get_note(anyPointer);
 
     crypto_account_get_accounts_len(anyPointer);
     crypto_account_get_account(anyPointer, 1);
@@ -39,6 +42,7 @@ public class SwiftUrRegistryFlutterPlugin: NSObject, FlutterPlugin {
     solana_sign_request_new();
     solana_sign_request_construct(anyPointer, anyPointer, anyPointer, 1, anyPointer, anyPointer, 1);
     solana_sign_request_get_ur_encoder(anyPointer);
+    solana_sign_request_get_request_id(anyPointer);
 
     solana_signature_get_signature(anyPointer);
     solana_signature_get_request_id(anyPointer);
@@ -50,6 +54,51 @@ public class SwiftUrRegistryFlutterPlugin: NSObject, FlutterPlugin {
 
     eth_signature_get_signature(anyPointer);
     eth_signature_get_request_id(anyPointer);
+
+    cardano_sign_request_new();
+    cardano_sign_request_construct(anyPointer, anyPointer, anyPointer, anyPointer, anyPointer);
+    cardano_sign_request_get_ur_encoder(anyPointer);
+    cardano_sign_request_get_request_id(anyPointer);
+
+    cardano_signature_get_witness_set(anyPointer);
+    cardano_signature_get_request_id(anyPointer);
+
+    cardano_sign_data_request_new();
+    cardano_sign_data_request_construct(anyPointer, anyPointer, anyPointer, anyPointer, anyPointer, anyPointer);
+    cardano_sign_data_request_get_ur_encoder(anyPointer);
+    cardano_sign_data_request_get_request_id(anyPointer);
+
+    cardano_sign_data_signature_new();
+    cardano_sign_data_signature_construct(anyPointer, anyPointer, anyPointer);
+    cardano_sign_data_signature_get_request_id(anyPointer);
+    cardano_sign_data_signature_get_signature(anyPointer);
+    cardano_sign_data_signature_get_public_key(anyPointer);
+
+    cardano_sign_cip8_data_request_new();
+    cardano_sign_cip8_data_request_construct(anyPointer, anyPointer, anyPointer, anyPointer, anyPointer, anyPointer, false, anyPointer, 0);
+    cardano_sign_cip8_data_request_get_ur_encoder(anyPointer);
+    cardano_sign_cip8_data_request_get_request_id(anyPointer);
+
+    cardano_sign_cip8_data_signature_new();
+    cardano_sign_cip8_data_signature_construct(anyPointer, anyPointer, anyPointer, anyPointer);
+    cardano_sign_cip8_data_signature_get_request_id(anyPointer);
+    cardano_sign_cip8_data_signature_get_signature(anyPointer);
+    cardano_sign_cip8_data_signature_get_public_key(anyPointer);
+    cardano_sign_cip8_data_signature_get_address_field(anyPointer);
+
+    cardano_catalyst_voting_registration_new();
+    cardano_catalyst_voting_registration_construct(anyPointer, anyPointer, anyPointer, anyPointer, anyPointer, anyPointer, 0, anyPointer, anyPointer, 0);
+    cardano_catalyst_voting_registration_get_ur_encoder(anyPointer);
+    cardano_catalyst_voting_registration_get_request_id(anyPointer);
+
+    cardano_catalyst_signature_new();
+    cardano_catalyst_signature_construct(anyPointer, anyPointer);
+    cardano_catalyst_signature_get_request_id(anyPointer);
+    cardano_catalyst_signature_get_signature(anyPointer);
+
+    cardano_sign_tx_hash_request_construct(anyPointer, anyPointer, anyPointer, anyPointer, anyPointer);
+    cardano_sign_tx_hash_request_get_ur_encoder(anyPointer);
+    cardano_sign_tx_hash_request_get_request_id(anyPointer);
 
     extend_crypto_multi_accounts_get_master_fingerprint(anyPointer);
     extend_crypto_multi_accounts_get_device(anyPointer);

--- a/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64/Headers/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64/Headers/URRegistryFFI/lib_ur_registry_ffi.h
@@ -99,6 +99,114 @@ PtrResponse eth_signature_get_signature(void *eth_signarure);
 
 PtrResponse eth_signature_get_request_id(void *eth_signature);
 
+PtrResponse cardano_sign_request_new(void);
+
+PtrResponse cardano_sign_request_construct(void *request_id,
+                                           void *sign_data,
+                                           void *utxos,
+                                           void *cert_keys,
+                                           void *origin);
+
+PtrResponse cardano_sign_request_get_ur_encoder(void *cardano_sign_request);
+
+PtrResponse cardano_sign_request_get_request_id(void *cardano_sign_request);
+
+PtrResponse cardano_signature_get_witness_set(void *cardano_signature);
+
+PtrResponse cardano_signature_get_request_id(void *cardano_signature);
+
+PtrResponse cardano_sign_data_request_new(void);
+
+PtrResponse cardano_sign_data_request_construct(void *request_id,
+                                                void *mfp,
+                                                void *sign_data,
+                                                void *derivation_path,
+                                                void *origin,
+                                                void *xpub);
+
+PtrResponse cardano_sign_data_request_get_ur_encoder(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_request_get_request_id(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_signature_new(void);
+
+PtrResponse cardano_sign_data_signature_construct(void *request_id,
+                                                  void *signature,
+                                                  void *public_key);
+
+PtrResponse cardano_sign_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_request_new(void);
+
+PtrResponse cardano_sign_cip8_data_request_construct(void *request_id,
+                                                     void *mfp,
+                                                     void *sign_data,
+                                                     void *derivation_path,
+                                                     void *xpub,
+                                                     void *origin,
+                                                     bool hash_payload,
+                                                     void *address_bench32,
+                                                     uint32_t address_type);
+
+PtrResponse cardano_sign_cip8_data_request_get_ur_encoder(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_request_get_request_id(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_signature_new(void);
+
+PtrResponse cardano_sign_cip8_data_signature_construct(void *request_id,
+                                                       void *signature,
+                                                       void *public_key,
+                                                       void *address_field);
+
+PtrResponse cardano_sign_cip8_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_address_field(void *signature);
+
+PtrResponse cardano_catalyst_voting_registration_new(void);
+
+PtrResponse cardano_catalyst_voting_registration_construct(void *request_id,
+                                                           void *mfp,
+                                                           void *delegations,
+                                                           void *stake_pub,
+                                                           void *payment_address,
+                                                           void *nonce,
+                                                           uint8_t voting_purpose,
+                                                           void *derivation_path,
+                                                           void *origin,
+                                                           uint8_t sign_type);
+
+PtrResponse cardano_catalyst_voting_registration_get_ur_encoder(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_voting_registration_get_request_id(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_signature_new(void);
+
+PtrResponse cardano_catalyst_signature_construct(void *request_id,
+                                                 void *signature);
+
+PtrResponse cardano_catalyst_signature_get_request_id(void *catalyst_signature);
+
+PtrResponse cardano_catalyst_signature_get_signature(void *catalyst_signature);
+
+PtrResponse cardano_sign_tx_hash_request_construct(void *request_id,
+                                                   void *tx_hash,
+                                                   void *paths,
+                                                   void *origin,
+                                                   void *address_list);
+
+PtrResponse cardano_sign_tx_hash_request_get_ur_encoder(void *cardano_sign_tx_hash_request);
+
+PtrResponse cardano_sign_tx_hash_request_get_request_id(void *cardano_sign_tx_hash_request);
+
 PtrResponse extend_crypto_multi_accounts_get_master_fingerprint(void *crypto_multi_accounts);
 
 PtrResponse extend_crypto_multi_accounts_get_device(void *crypto_multi_accounts);

--- a/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64/Headers/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64/Headers/URRegistryFFI/lib_ur_registry_ffi.h
@@ -40,6 +40,8 @@ PtrResponse crypto_hd_key_get_name(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_path(void *crypto_hdkey);
 
+PtrResponse crypto_hd_key_get_children_path(void *crypto_hdkey);
+
 PtrResponse crypto_hd_key_get_source_fingerprint(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
@@ -47,6 +49,8 @@ PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
 PtrResponse crypto_hd_key_get_depth(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_note(void *crypto_hdkey);
+
+PtrResponse crypto_hd_key_get_bip32_xpub(void *crypto_hdkey);
 
 PtrResponse crypto_account_get_accounts_len(void *crypto_account);
 

--- a/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64_x86_64-simulator/Headers/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64_x86_64-simulator/Headers/URRegistryFFI/lib_ur_registry_ffi.h
@@ -99,6 +99,114 @@ PtrResponse eth_signature_get_signature(void *eth_signarure);
 
 PtrResponse eth_signature_get_request_id(void *eth_signature);
 
+PtrResponse cardano_sign_request_new(void);
+
+PtrResponse cardano_sign_request_construct(void *request_id,
+                                           void *sign_data,
+                                           void *utxos,
+                                           void *cert_keys,
+                                           void *origin);
+
+PtrResponse cardano_sign_request_get_ur_encoder(void *cardano_sign_request);
+
+PtrResponse cardano_sign_request_get_request_id(void *cardano_sign_request);
+
+PtrResponse cardano_signature_get_witness_set(void *cardano_signature);
+
+PtrResponse cardano_signature_get_request_id(void *cardano_signature);
+
+PtrResponse cardano_sign_data_request_new(void);
+
+PtrResponse cardano_sign_data_request_construct(void *request_id,
+                                                void *mfp,
+                                                void *sign_data,
+                                                void *derivation_path,
+                                                void *origin,
+                                                void *xpub);
+
+PtrResponse cardano_sign_data_request_get_ur_encoder(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_request_get_request_id(void *cardano_sign_data_request);
+
+PtrResponse cardano_sign_data_signature_new(void);
+
+PtrResponse cardano_sign_data_signature_construct(void *request_id,
+                                                  void *signature,
+                                                  void *public_key);
+
+PtrResponse cardano_sign_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_request_new(void);
+
+PtrResponse cardano_sign_cip8_data_request_construct(void *request_id,
+                                                     void *mfp,
+                                                     void *sign_data,
+                                                     void *derivation_path,
+                                                     void *xpub,
+                                                     void *origin,
+                                                     bool hash_payload,
+                                                     void *address_bench32,
+                                                     uint32_t address_type);
+
+PtrResponse cardano_sign_cip8_data_request_get_ur_encoder(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_request_get_request_id(void *cardano_sign_cip8_data_request);
+
+PtrResponse cardano_sign_cip8_data_signature_new(void);
+
+PtrResponse cardano_sign_cip8_data_signature_construct(void *request_id,
+                                                       void *signature,
+                                                       void *public_key,
+                                                       void *address_field);
+
+PtrResponse cardano_sign_cip8_data_signature_get_request_id(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_signature(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_public_key(void *signature);
+
+PtrResponse cardano_sign_cip8_data_signature_get_address_field(void *signature);
+
+PtrResponse cardano_catalyst_voting_registration_new(void);
+
+PtrResponse cardano_catalyst_voting_registration_construct(void *request_id,
+                                                           void *mfp,
+                                                           void *delegations,
+                                                           void *stake_pub,
+                                                           void *payment_address,
+                                                           void *nonce,
+                                                           uint8_t voting_purpose,
+                                                           void *derivation_path,
+                                                           void *origin,
+                                                           uint8_t sign_type);
+
+PtrResponse cardano_catalyst_voting_registration_get_ur_encoder(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_voting_registration_get_request_id(void *cardano_catalyst_voting_registration);
+
+PtrResponse cardano_catalyst_signature_new(void);
+
+PtrResponse cardano_catalyst_signature_construct(void *request_id,
+                                                 void *signature);
+
+PtrResponse cardano_catalyst_signature_get_request_id(void *catalyst_signature);
+
+PtrResponse cardano_catalyst_signature_get_signature(void *catalyst_signature);
+
+PtrResponse cardano_sign_tx_hash_request_construct(void *request_id,
+                                                   void *tx_hash,
+                                                   void *paths,
+                                                   void *origin,
+                                                   void *address_list);
+
+PtrResponse cardano_sign_tx_hash_request_get_ur_encoder(void *cardano_sign_tx_hash_request);
+
+PtrResponse cardano_sign_tx_hash_request_get_request_id(void *cardano_sign_tx_hash_request);
+
 PtrResponse extend_crypto_multi_accounts_get_master_fingerprint(void *crypto_multi_accounts);
 
 PtrResponse extend_crypto_multi_accounts_get_device(void *crypto_multi_accounts);

--- a/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64_x86_64-simulator/Headers/URRegistryFFI/lib_ur_registry_ffi.h
+++ b/interfaces/ur_registry_flutter/ios/ur_registry_flutter/ur_registry_ffi.xcframework/ios-arm64_x86_64-simulator/Headers/URRegistryFFI/lib_ur_registry_ffi.h
@@ -40,6 +40,8 @@ PtrResponse crypto_hd_key_get_name(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_path(void *crypto_hdkey);
 
+PtrResponse crypto_hd_key_get_children_path(void *crypto_hdkey);
+
 PtrResponse crypto_hd_key_get_source_fingerprint(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
@@ -47,6 +49,8 @@ PtrResponse crypto_hd_key_get_account_index(void *crypto_hdkey, uint32_t level);
 PtrResponse crypto_hd_key_get_depth(void *crypto_hdkey);
 
 PtrResponse crypto_hd_key_get_note(void *crypto_hdkey);
+
+PtrResponse crypto_hd_key_get_bip32_xpub(void *crypto_hdkey);
 
 PtrResponse crypto_account_get_accounts_len(void *crypto_account);
 

--- a/interfaces/ur_registry_flutter/pubspec.yaml
+++ b/interfaces/ur_registry_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ur_registry_flutter
 description: An ffi bridge for ur_registry_rust and flutter.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/KeystoneHQ/ur-registry-rust/interfaces/ur_registry_flutter
 
 environment:


### PR DESCRIPTION
## Summary
- Keep all Dart FFI lookup symbols referenced by the iOS Swift Package Manager shim so they remain available at runtime.
- Add missing iOS header declarations for Cardano and HD key FFI functions.
- Bump `ur_registry_flutter` to `0.5.1` and make iOS XCFramework generation idempotent.

## Verification
- `make generate_ios`
- Swift typecheck against Flutter.framework and URRegistryFFI module map
- Compared Dart FFI lookups against Swift dummyBundle and iOS headers; zero missing symbols